### PR TITLE
Reuse getSeed function (and the memSeed cache) to compute contestant seeds

### DIFF
--- a/js/calculate.js
+++ b/js/calculate.js
@@ -51,12 +51,7 @@ function process(contestants) {
   }
   reassignRanks(contestants);
   for (var i = 0; i < contestants.content.length; i++) {
-    contestants.content[i].seed = 1.0;
-    for (var j = 0; j < contestants.content.length; j++) {
-      if (i != j) {
-        contestants.content[i].seed += getEloWinProbability(contestants.content[j].rating, contestants.content[i].rating);
-      }
-    }
+    contestants.content[i].seed = getSeed(contestants, contestants.content[i].rating) - 0.5;
   }
   for (var i = 0; i < contestants.content.length; i++) {
     var midRank = Math.sqrt(contestants.content[i].rank * contestants.content[i].seed);


### PR DESCRIPTION
This only matters when the user compute rating change on one contest multiple times (otherwise the download time dominates)

Note: the two slowest computation parts are: compute contestants seed (O(n^2) and compute `needRating` / `delta` (O(n*m)). (where n is the number of contestants and m is the number of distinct rating values.

`getSeed` is used to compute contestant seed, but it can be used to compute contestant seeds as well. Just subtract the user's own win probability from the sum.

Because this shares the `memSeed` cache the time complexity is reduced from O(n^2) to O(n*m). Which is about 15s -> 2s on some large contest such as Good Bye 2018 (id 1091)

Apparently the O(n^2) stable insertion sort below doesn't take much time. (I think that's because the ranking is approximately in the same order as the rating)