### PR TITLE
Exclude existing user, fix getSeed overcounting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codeforces Visualizer
 
-This is code repository for a simple analytics visualization site for [Codeforces online judge](http://codeforces.com/) users using [Codeforeces API](http://codeforces.com/api/help). The site is currently hosted at [here](https://cfviz.netlify.com/).
+This is code repository for a simple analytics visualization site for [Codeforces online judge](http://codeforces.com/) users using [Codeforces API](http://codeforces.com/api/help). The site is currently hosted at [here](https://cfviz.netlify.com/).
 
 ### Current features
 

--- a/js/calculate.js
+++ b/js/calculate.js
@@ -59,20 +59,9 @@ function process(contestants) {
     contestants.content[i].delta      = parseInt((contestants.content[i].needRating - contestants.content[i].rating) / 2);
   }
 
-
-
-  var tmp;
-  var j = 0;
-  for (var i = 1; i < contestants.content.length; i++) {
-    j = i;
-    while (j > 0 && contestants.content[j].rating > contestants.content[j - 1].rating) {
-      tmp                        = contestants.content[j];
-      contestants.content[j]     = contestants.content[j - 1];
-      contestants.content[j - 1] = tmp;
-      j--;
-    }
-  }
-  
+  contestants.content.sort(function(a, b) {
+    return b.rating - a.rating;
+  });
 
   {
     var sum = 0;

--- a/js/calculate.js
+++ b/js/calculate.js
@@ -14,12 +14,12 @@ function getSeed(contestants, rating) {
   return result;
 }
 
-function getRatingToRank(contestants, rank) {
+function getRatingToRank(contestants, realRating, rank) {
   var left = 1;
   var right = 8000;
   while (right - left > 1) {
     var mid = parseInt((left + right) / 2);
-    if (getSeed(contestants, mid) < rank) {
+    if (getSeed(contestants, mid) - getEloWinProbability(realRating, mid) < rank) {
       right = mid;
     } else {
       left = mid;
@@ -51,12 +51,12 @@ function process(contestants) {
   }
   reassignRanks(contestants);
   for (var i = 0; i < contestants.content.length; i++) {
-    contestants.content[i].seed = getSeed(contestants, contestants.content[i].rating) - 0.5;
-  }
-  for (var i = 0; i < contestants.content.length; i++) {
-    var midRank = Math.sqrt(contestants.content[i].rank * contestants.content[i].seed);
-    contestants.content[i].needRating = parseInt(getRatingToRank(contestants, midRank));
-    contestants.content[i].delta      = parseInt((contestants.content[i].needRating - contestants.content[i].rating) / 2);
+    var contestant = contestants.content[i];
+    var rating = contestant.rating;
+    contestant.seed = getSeed(contestants, rating) - 0.5;
+    var midRank = Math.sqrt(contestant.rank * contestant.seed);
+    contestant.needRating = parseInt(getRatingToRank(contestants, rating, midRank));
+    contestant.delta      = parseInt((contestant.needRating - contestant.rating) / 2);
   }
 
   contestants.content.sort(function(a, b) {

--- a/js/vir.js
+++ b/js/vir.js
@@ -12,6 +12,7 @@ var points = -1;
 var rating = -1;
 var rank = -1;
 var penalty = -1;
+var userHandle = null;
 
 $(document).ready(function() {
   $('#inputform').submit(function(e) {
@@ -29,6 +30,7 @@ $(document).ready(function() {
     rating = $('#rating').val().trim();
     points = $('#points').val().trim();
     penalty = $('#penalty').val().trim();
+    userHandle = $('#handle').val().trim();
 
     if(!(newContestId && rating && points)) {
       err_message('contestIdDiv', 'All fields required');
@@ -78,6 +80,7 @@ function getDataFailed() {
 }
 
 function refresh() {
+  var handleFound = false;
   for (var i = 0; i < rows.length; i++) {
     // trying to guess what what would have been his rank if he participated in the real contest
     if ((points > rows[i].points || (points == rows[i].points && penalty <= rows[i].penalty))
@@ -86,8 +89,17 @@ function refresh() {
       places.push(rows[i].rank);
       rank = rows[i].rank;
     }
-    places.push(rows[i].rank)
-    handles.push(rows[i].party.members[0].handle);
+    if (userHandle == rows[i].party.members[0].handle) {
+      handleFound = true;
+    } else {
+      places.push(rows[i].rank)
+      handles.push(rows[i].party.members[0].handle);
+    }
+  }
+
+  if (userHandle != '' && !handleFound) {
+    err_message('handleDiv', 'User did not participate in contest')
+    return
   }
 
   for (var i = 0; i < handles.length; i++) {

--- a/js/vir.js
+++ b/js/vir.js
@@ -11,6 +11,7 @@ var contestId = -1;
 var points = -1;
 var rating = -1;
 var rank = -1;
+var penalty = -1;
 
 $(document).ready(function() {
   $('#inputform').submit(function(e) {
@@ -42,19 +43,19 @@ $(document).ready(function() {
       showMessage("Downloading data can take a few minutes. Thanks for your patience.");
       contestId = newContestId;
 
-      req1 = $.get(api_url + 'contest.standings', { contestId: contestId }, function(data, status) {
+      var req1 = $.get(api_url + 'contest.standings', { contestId: contestId }, function(data, status) {
         rows = data.result.rows;
       }).fail(getDataFailed);
 
       // we need all the participants' ratings before the contest
-      req2 = $.get(api_url + 'contest.ratingChanges', { contestId: contestId }, function(data, status) {
+      var req2 = $.get(api_url + 'contest.ratingChanges', { contestId: contestId }, function(data, status) {
         if (data.result.length == 0) {
           getDataFailed();
           req1.abort();
           return;
         }
         for (var i = 0; i < data.result.length; i++) {
-          change = data.result[i];
+          var change = data.result[i];
           ratingsDict[change.handle] = change.oldRating;
         }
       }).fail(getDataFailed);
@@ -93,7 +94,7 @@ function refresh() {
     ratings[i] = handles[i] in ratingsDict ? ratingsDict[handles[i]] : rating;
   }
 
-  results = CalculateRatingChanges(ratings, places, handles);
+  var results = CalculateRatingChanges(ratings, places, handles);
   showResult(results);
 }
 

--- a/js/vir.js
+++ b/js/vir.js
@@ -108,7 +108,7 @@ function resetData() {
   rank = -1;
 }
 
-function showResult(resluts) {
+function showResult(results) {
   $('#mainSpinner').removeClass('is-active');
   $('#result').removeClass('hidden');
   for (var i = 0; i < results.length; i++) {

--- a/js/vir.js
+++ b/js/vir.js
@@ -32,14 +32,22 @@ $(document).ready(function() {
     penalty = $('#penalty').val().trim();
     userHandle = $('#handle').val().trim();
 
-    if(!(newContestId && rating && points)) {
-      err_message('contestIdDiv', 'All fields required');
+    if(!newContestId) {
+      err_message('contestIdDiv', 'Not valid contest ID');
       return;
     }
-
-    var newContestId = $('#contestId').val().trim();
-    rating = $('#rating').val().trim();
-    points = $('#points').val().trim();
+    if(!points) {
+      err_message('pointsDiv', 'Not valid points');
+      return;
+    }
+    if(!penalty) {
+      err_message('penaltyDiv', 'Not valid penalty');
+      return;
+    }
+    if(!(rating || userHandle)) {
+      err_message('ratingDiv', 'Rating must not be empty without user handle');
+      return;
+    }
 
     if (newContestId != contestId || rows.length == 0 || Object.keys(ratingsDict).length == 0) {
       showMessage("Downloading data can take a few minutes. Thanks for your patience.");
@@ -101,6 +109,9 @@ function refresh() {
     err_message('handleDiv', 'User did not participate in contest')
     return
   }
+
+  if (!rating)
+    rating = ratingsDict[userHandle];
 
   for (var i = 0; i < handles.length; i++) {
     ratings[i] = handles[i] in ratingsDict ? ratingsDict[handles[i]] : rating;

--- a/sw.js
+++ b/sw.js
@@ -6,12 +6,12 @@ workbox.precaching.precacheAndRoute([
   { url: '/index.html', revision: '1115' },
   { url: '/about.html', revision: '1111' },
   { url: '/compare.html', revision: '1111' },
-  { url: '/virtual-rating-change.html', revision: '1111' },
+  { url: '/virtual-rating-change.html', revision: '1112' },
   { url: '/js/compare_helper.js', revision: '1113' },
   { url: '/js/compare.js', revision: '1111' },
-  { url: '/js/calculate.js', revision: '1111' },
+  { url: '/js/calculate.js', revision: '1112' },
   { url: '/js/single.js', revision: '1112' },
-  { url: '/js/vir.js', revision: '1111' }
+  { url: '/js/vir.js', revision: '1112' }
 ]);
 
 workbox.routing.registerRoute(

--- a/virtual-rating-change.html
+++ b/virtual-rating-change.html
@@ -136,6 +136,11 @@
               <label class="mdl-textfield__label" for="handle">Points</label>
               <span id="pointsDivErr" class="mdl-textfield__error">Not valid points</span>
             </div>
+            <div class="mdl-textfield mdl-js-textfield" id="handleDiv">
+              <input type="text" class="mdl-textfield__input" name="handle" id="handle">
+              <label class="mdl-textfield__label" for="handle">Your handle (leave empty if you did not participate in the contest)</label>
+              <span id="handleDivErr" class="mdl-textfield__error"></span>
+            </div>
             <div class="mdl-textfield mdl-js-textfield" id="penaltyDiv">
               <input type="number" class="mdl-textfield__input" name="penalty" id="penalty">
               <label class="mdl-textfield__label" for="handle">Penalty (0 if not exist)</label>

--- a/virtual-rating-change.html
+++ b/virtual-rating-change.html
@@ -148,7 +148,7 @@
             </div>
             <div class="mdl-textfield mdl-js-textfield" id="ratingDiv">
               <input type="number" class="mdl-textfield__input" name="rating" id="rating">
-              <label class="mdl-textfield__label" for="handle">Old Rating</label>
+              <label class="mdl-textfield__label" for="handle">Old Rating (may be left empty if you participated)</label>
               <span id="ratingDivErr" class="mdl-textfield__error">Not valid rating</span>
             </div>
             <br>


### PR DESCRIPTION
1. There are some variables assigned to without `var`. They can be detected with `'use strict';`.
2. The JS sort function is usually faster than bubble sort (currently the bubble sort doesn't take much time) and also shorter.
3. Currently `getSeed` computes, assuming that the user with rating `rating` is not included in `contestants`. If they're included, then it's necessary to subtract the win probability from the result.
4. While the website says that it can compute both "your rating change if you participated in a contest live rather than virtual" and "if you could solve one more problem in the last contest", it gives wrong result in the latter case. It's necessary to remove the "real" user from the list to get the correct result.

In the old version, with contest ID 1205, the rating change of Benq is computed to be +8 while the real result is -4. In the new version, all the computed rating change for that contest are correct.

The description for some fields are a bit long (and may not fit in the box on some smaller screen), but I don't know how to fix it.