### PR TITLE
use actual rating in added point

### DIFF
--- a/js/compare_helper.js
+++ b/js/compare_helper.js
@@ -253,11 +253,11 @@ function alignTimeline(r1, r2) {
       j++;
     } else if (compDate(r1[i][0], r2[j][0]) < 0) {
       if (j === 0) ret.push([new Date(r1[i][0] * 1000), r1[i][1], null]);
-      else ret.push([new Date(r1[i][0] * 1000), r1[i][1], r2[j][1]]);
+      else ret.push([new Date(r1[i][0] * 1000), r1[i][1], r2[j - 1][1]]);
       i++;
     } else {
       if (i === 0) ret.push([new Date(r2[j][0] * 1000), null, r2[j][1]]);
-      else ret.push([new Date(r2[j][0] * 1000), r1[i][1], r2[j][1]]);
+      else ret.push([new Date(r2[j][0] * 1000), r1[i - 1][1], r2[j][1]]);
       j++;
     }
 


### PR DESCRIPTION
Actual rating at the moment is the last rating _before_ that moment, not after.

For example, now actual graphs look like this: (i use a script for multiple graphs)
<img src="https://user-images.githubusercontent.com/38928209/69484141-b5433d80-0e40-11ea-9419-6f0fa81696b0.png"  width="150">

But your site shows this:
<img src="https://user-images.githubusercontent.com/38928209/69484176-3d294780-0e41-11ea-965b-2698a3744593.png"  width="150">

I noticed it, because this two graphs never intersected in real life. And after this commit:
<img src="https://user-images.githubusercontent.com/38928209/69484196-a6a95600-0e41-11ea-89de-18c1d4155666.png"  width="150">



