### PR TITLE
single.js: fixed solvedWithOneSub calculation

### DIFF
--- a/js/single.js
+++ b/js/single.js
@@ -498,7 +498,7 @@ function drawCharts() {
       maxAcProblem = p;
     }
 
-    if (problems[p].solved == problems[p].attempts) solvedWithOneSub++;
+    if (problems[p].solved > 0 && problems[p].attempts == 1) solvedWithOneSub++;
   }
   $('#numbers').removeClass('hidden');
   $('#unsolvedCon').removeClass('hidden');


### PR DESCRIPTION
Hello @sjsakib,

This pull request fixes a bug with the calculation of problems solved with one submission.

`problems[problemId].attempts` stores count of attemps before first submissions
`problems[problemId].solved` stores count of right submissions
`solvedWithOneSub` stores the count of how many problems were solved with one submission. 

Currently we do
`if (problems[problemId].attempts == problems[problemId].solved) solvedWithOneSub++;`
however this will prove wrong in the case where the first submission was right, and then author went on to submit more right submissions.

Changing it to
`if (problems[problemId].attemps == 1) solvedWithOneSub++; `
seems to fix the issue in my case.

Please let me know if this approach could lead to issues elsewhere!

Signed-off-by: Archit Pandey <architpandeynitk@gmail.com>