### PR TITLE
Reducing multiple counting #28

### DIFF
--- a/js/single.js
+++ b/js/single.js
@@ -39,8 +39,7 @@ $(document).ready(function () {
 
     // getting all the submissions of a user
     req1 = $.get(api_url + 'user.status', { handle: handle }, function (data, status) {
-      console.log(data);
-
+     
       $('.sharethis').removeClass('hidden');
 
       if (data.result.length < 1) {
@@ -161,7 +160,7 @@ $(document).ready(function () {
 
     // With this request we get all the rating changes of the user
     req2 = $.get(api_url + 'user.rating', { handle: handle }, function (data, status) {
-      console.log(data);
+      
       if (data.result.length < 1) {
         err_message('handleDiv', 'No contests');
         return;
@@ -505,7 +504,6 @@ function drawCharts() {
   var unsolved = [];
   var solvedWithOneSub = 0;
   for (var p in problems) {
-    console.log(problems[p]);
     tried++;
     if (problems[p].solved > 0) solved++;
     if (problems[p].solved === 0) unsolved.push(problems[p].problemlink);


### PR DESCRIPTION
This is how reduced multiple counting.

Research part -- 
1)  90% of the (Div-1 and Div-2) which happen same day but separately have consecutive contest ID.

Why there was multiple counting -- 
1) As of now the unique Id assigned to a problem is (contestID + index of problem).
 This approach of unique index is not that accurate because let's say you have same problem on same day in 
 Div-1 and Div-2 separately at index (A and C) then they will be considered different problems (1334-A , 1335-C).
 This is why there was a problem of multiple counting.

How i solved it -- 
1) I created unique id of problem as (contestID + problemname + rating of problem).
    Now for each problem we have two scenario.
    i) Current problem is Div-1 A and we have already solved Div-2 C here both Div-1 and Div-2 round will have same name 
        and rating of the problem so i am checking if in just next contest we have solved a problem of same name and 
         same rating and doing rest of updates.
    ii) Same for the case if current problem is Div-2 C then i am checking previous contest.

How much new code affects accuracy -- 
1) Number of unsolved problem might reduce bcoz you might have 3 WA in Div-1 A but 1 AC in Div-2 C.
2) Max AC of any problem will now to sum of AC of both Div-1 A and Div-2 C.
3) Rating wise count of some problem might be reduced bcoz now we will count only one between (Div-1 A and Div-2 C).
4) Solved with one submission might reduce bcoz may be i have AC in one go in Div-1 A but i have already have 20 WA in 
    Div-2 C.
