### PR TITLE
Codeforces API url changed to latest working url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codeforces Visualizer
 
-This is code repository for a simple analytics visualization site for [Codeforces online judge](http://codeforces.com/) users using [Codeforces API](http://codeforces.com/api/help). The site is currently hosted at [here](https://cfviz.netlify.com/).
+This is code repository for a simple analytics visualization site for [Codeforces online judge](http://codeforces.com/) users using [Codeforces API](https://codeforces.com/apiHelp). The site is currently hosted at [here](https://cfviz.netlify.com/).
 
 ### Current features
 


### PR DESCRIPTION
I've fixed the issue with the API URL. Please accept this pull request.